### PR TITLE
feat: Add Lido Finance as a Vault

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dappio-wonderland/navigator",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Dappio Navigator: The Universal Typescript Client for Instantiating DeFi Protocols",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "testLifinity": "mocha --require ts-node/register --timeout 10000000 ./test/lifinity.ts",
     "testTulip": "mocha --require ts-node/register --timeout 10000000 ./test/tulip.ts",
     "testFriktion": "mocha --require ts-node/register --timeout 10000000 ./test/friktion.ts",
-    "testNftFinance": "mocha --require ts-node/register --timeout 10000000 ./test/nftFinance.ts"
+    "testNftFinance": "mocha --require ts-node/register --timeout 10000000 ./test/nftFinance.ts",
+    "testLido": "mocha --require ts-node/register --timeout 10000000 ./test/lido.ts"
   },
   "keywords": [],
   "author": "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,4 +10,5 @@ export * as tulip from "./tulip";
 export * as nftFinance from "./nftFinance";
 export * as utils from "./utils";
 export * as friktion from "./friktion";
+export * as lido from "./lido";
 export * from "./types";

--- a/src/lido/ids.ts
+++ b/src/lido/ids.ts
@@ -1,0 +1,7 @@
+import { PublicKey } from "@solana/web3.js";
+
+// Program ID
+
+export const LIDO_PROGRAM_ID = new PublicKey("CrX7kMhLC3cSsXJdT7JDgqrRVWGnUpX3gfEfxxU2NVLi");
+export const LIDO_ADDRESS = new PublicKey("49Yi1TKkNyYjPAFdR9LBvoHcUjuPX4Df5T5yv39w2XTn");
+export const ST_SOL_MINT_ADDRESS = new PublicKey("7dHbWXmci3dT8UFYWYZweBLXgycu7Y3iL6trKn1Y7ARj");

--- a/src/lido/ids.ts
+++ b/src/lido/ids.ts
@@ -1,7 +1,5 @@
 import { PublicKey } from "@solana/web3.js";
 
-// Program ID
-
 export const LIDO_PROGRAM_ID = new PublicKey("CrX7kMhLC3cSsXJdT7JDgqrRVWGnUpX3gfEfxxU2NVLi");
 export const LIDO_ADDRESS = new PublicKey("49Yi1TKkNyYjPAFdR9LBvoHcUjuPX4Df5T5yv39w2XTn");
 export const ST_SOL_MINT_ADDRESS = new PublicKey("7dHbWXmci3dT8UFYWYZweBLXgycu7Y3iL6trKn1Y7ARj");

--- a/src/lido/ids.ts
+++ b/src/lido/ids.ts
@@ -1,12 +1,5 @@
 import { PublicKey } from "@solana/web3.js";
 
-// Mainnet addresses
 export const LIDO_PROGRAM_ID = new PublicKey("CrX7kMhLC3cSsXJdT7JDgqrRVWGnUpX3gfEfxxU2NVLi");
 export const LIDO_ADDRESS = new PublicKey("49Yi1TKkNyYjPAFdR9LBvoHcUjuPX4Df5T5yv39w2XTn");
 export const ST_SOL_MINT_ADDRESS = new PublicKey("7dHbWXmci3dT8UFYWYZweBLXgycu7Y3iL6trKn1Y7ARj");
-
-// Testnet addresses
-
-// export const LIDO_PROGRAM_ID = new PublicKey("6RRggYnFe2EcD543QXrE3Wxp1Kgcq8qctwRrNnvjoYsL");
-// export const LIDO_ADDRESS = new PublicKey("Hcqw2G2FkBhBiDZz3PXFBUKuMQiKMJmXvcfqRaXkyNXF");
-// export const ST_SOL_MINT_ADDRESS = new PublicKey("Bz2UPiXJmCQYT8XQHaPPXG3fywNp2TENav5dcJdX9q21");

--- a/src/lido/ids.ts
+++ b/src/lido/ids.ts
@@ -1,5 +1,12 @@
 import { PublicKey } from "@solana/web3.js";
 
+// Mainnet addresses
 export const LIDO_PROGRAM_ID = new PublicKey("CrX7kMhLC3cSsXJdT7JDgqrRVWGnUpX3gfEfxxU2NVLi");
 export const LIDO_ADDRESS = new PublicKey("49Yi1TKkNyYjPAFdR9LBvoHcUjuPX4Df5T5yv39w2XTn");
 export const ST_SOL_MINT_ADDRESS = new PublicKey("7dHbWXmci3dT8UFYWYZweBLXgycu7Y3iL6trKn1Y7ARj");
+
+// Testnet addresses
+
+// export const LIDO_PROGRAM_ID = new PublicKey("6RRggYnFe2EcD543QXrE3Wxp1Kgcq8qctwRrNnvjoYsL");
+// export const LIDO_ADDRESS = new PublicKey("Hcqw2G2FkBhBiDZz3PXFBUKuMQiKMJmXvcfqRaXkyNXF");
+// export const ST_SOL_MINT_ADDRESS = new PublicKey("Bz2UPiXJmCQYT8XQHaPPXG3fywNp2TENav5dcJdX9q21");

--- a/src/lido/index.ts
+++ b/src/lido/index.ts
@@ -36,10 +36,10 @@ export interface VaultInfo extends IVaultInfo {
   solReserveAuthorityBumpSeed: BN;
   stakeAuthorityBumpSeed: BN;
   mintAuthorityBumpSeed: BN;
-  rewardsWithdrawAuthorityBumpSeed: BN;
+  rewardsWithdrawAuthorityBumpSeed?: BN;
   rewardDistribution: {
     treasuryFee: BN;
-    validationFee: BN;
+    validationFee?: BN;
     developerFee: BN;
     stSolAppreciation: BN;
   };
@@ -65,10 +65,12 @@ export interface VaultInfo extends IVaultInfo {
       count: BN;
     };
   };
+  validatorsAccount?: PublicKey;
   validators: {
     entries: ValidatorInfo[];
     maximumEntries: BN;
   };
+  maintainersAccount?: PublicKey;
   maintainers: {
     entries: {
       pubkey: PublicKey;

--- a/src/lido/index.ts
+++ b/src/lido/index.ts
@@ -86,5 +86,5 @@ export interface VaultInfo extends IVaultInfo {
 }
 
 export interface DepositorInfo extends IDepositorInfo {
-  rawAccount: RawAccount;
+  tokenAccount: RawAccount;
 }

--- a/src/lido/index.ts
+++ b/src/lido/index.ts
@@ -26,6 +26,18 @@ export interface ValidatorInfo {
   };
 }
 
+export interface ValidatorAccountInfo {
+  entries: ValidatorInfo[];
+  maximumEntries: BN;
+}
+
+export interface MaintainerAccountInfo {
+  entries: {
+    pubkey: PublicKey;
+  }[];
+  maximumEntries: BN;
+}
+
 export interface VaultInfo extends IVaultInfo {
   lidoVersion: BN;
   manager: PublicKey;
@@ -67,17 +79,9 @@ export interface VaultInfo extends IVaultInfo {
     };
   };
   validatorList?: PublicKey;
-  validators: {
-    entries: ValidatorInfo[];
-    maximumEntries: BN;
-  };
+  validators?: ValidatorAccountInfo;
   maintainerList?: PublicKey;
-  maintainers: {
-    entries: {
-      pubkey: PublicKey;
-    }[];
-    maximumEntries: BN;
-  };
+  maintainers?: MaintainerAccountInfo;
   maxCommissionPercentage?: BN;
 }
 

--- a/src/lido/index.ts
+++ b/src/lido/index.ts
@@ -6,6 +6,25 @@ import { PublicKey } from "@solana/web3.js";
 import BN from "bn.js";
 import { IDepositorInfo, IVaultInfo } from "../types";
 
+export interface ValidatorInfo {
+  pubkey: PublicKey;
+  entry: {
+    feeCredit: BN;
+    feeAddress: PublicKey;
+    stakeSeeds: {
+      begin: BN;
+      end: BN;
+    };
+    unstakeSeeds: {
+      begin: BN;
+      end: BN;
+    };
+    stakeAccountsBalance: BN;
+    unstakeAccountsBalance: BN;
+    active: BN;
+  };
+}
+
 export interface VaultInfo extends IVaultInfo {
   lidoVersion: BN;
   manager: PublicKey;
@@ -47,24 +66,7 @@ export interface VaultInfo extends IVaultInfo {
     };
   };
   validators: {
-    entries: {
-      pubkey: PublicKey;
-      entry: {
-        feeCredit: BN;
-        feeAddress: PublicKey;
-        stakeSeeds: {
-          begin: BN;
-          end: BN;
-        };
-        unstakeSeeds: {
-          begin: BN;
-          end: BN;
-        };
-        stakeAccountsBalance: BN;
-        unstakeAccountsBalance: BN;
-        active: BN;
-      };
-    }[];
+    entries: ValidatorInfo[];
     maximumEntries: BN;
   };
   maintainers: {

--- a/src/lido/index.ts
+++ b/src/lido/index.ts
@@ -1,13 +1,80 @@
 export * from "./ids";
 export * from "./infos";
 
+import { PublicKey } from "@solana/web3.js";
 import BN from "bn.js";
 import { IDepositorInfo, IVaultInfo } from "../types";
 
-// TODO: Add relevant fields
 export interface VaultInfo extends IVaultInfo {
-  amount: BN;
+  lidoVersion: BN;
+  manager: PublicKey;
+  exchangeRate: {
+    computedInEpoch: BN;
+    stSolSupply: BN;
+    solBalance: BN;
+  };
+  solReserveAuthorityBumpSeed: BN;
+  stakeAuthorityBumpSeed: BN;
+  mintAuthorityBumpSeed: BN;
+  rewardsWithdrawAuthorityBumpSeed: BN;
+  rewardDistribution: {
+    treasuryFee: BN;
+    validationFee: BN;
+    developerFee: BN;
+    stSolAppreciation: BN;
+  };
+  feeRecipients: {
+    treasuryAccount: PublicKey;
+    developerAccount: PublicKey;
+  };
+  metrics: {
+    feeTreasurySolTotal: BN;
+    feeValidationSolTotal: BN;
+    feeDeveloperSolTotal: BN;
+    stSolAppreciationTotal: BN;
+    feeTreasuryStSolTotal: BN;
+    feeValidationStSolTotal: BN;
+    feeDeveloperStSolTotal: BN;
+    depositAmount: {
+      counts: BN[];
+      total: BN;
+    };
+    withdrawAmount: {
+      totalStSolAmount: BN;
+      totalSolAmount: BN;
+      count: BN;
+    };
+  };
+  validators: {
+    entries: {
+      pubkey: PublicKey;
+      entry: {
+        feeCredit: BN;
+        feeAddress: PublicKey;
+        stakeSeeds: {
+          begin: BN;
+          end: BN;
+        };
+        unstakeSeeds: {
+          begin: BN;
+          end: BN;
+        };
+        stakeAccountsBalance: BN;
+        unstakeAccountsBalance: BN;
+        active: BN;
+      };
+    }[];
+    maximumEntries: BN;
+  };
+  maintainers: {
+    entries: {
+      pubkey: PublicKey;
+    }[];
+    maximumEntries: BN;
+  };
 }
 
-// TODO: Add relavant fields
-export interface DepositorInfo extends IDepositorInfo {}
+export interface DepositorInfo extends IDepositorInfo {
+  mint: PublicKey;
+  amount: BN;
+}

--- a/src/lido/index.ts
+++ b/src/lido/index.ts
@@ -1,0 +1,1 @@
+export * from "./infos";

--- a/src/lido/index.ts
+++ b/src/lido/index.ts
@@ -1,1 +1,13 @@
+export * from "./ids";
 export * from "./infos";
+
+import BN from "bn.js";
+import { IDepositorInfo, IVaultInfo } from "../types";
+
+// TODO: Add relevant fields
+export interface VaultInfo extends IVaultInfo {
+  amount: BN;
+}
+
+// TODO: Add relavant fields
+export interface DepositorInfo extends IDepositorInfo {}

--- a/src/lido/index.ts
+++ b/src/lido/index.ts
@@ -1,6 +1,7 @@
 export * from "./ids";
 export * from "./infos";
 
+import { RawAccount } from "@solana/spl-token-v2";
 import { PublicKey } from "@solana/web3.js";
 import BN from "bn.js";
 import { IDepositorInfo, IVaultInfo } from "../types";
@@ -75,6 +76,5 @@ export interface VaultInfo extends IVaultInfo {
 }
 
 export interface DepositorInfo extends IDepositorInfo {
-  mint: PublicKey;
-  amount: BN;
+  rawAccount: RawAccount;
 }

--- a/src/lido/index.ts
+++ b/src/lido/index.ts
@@ -7,10 +7,10 @@ import BN from "bn.js";
 import { IDepositorInfo, IVaultInfo } from "../types";
 
 export interface ValidatorInfo {
-  pubkey: PublicKey;
+  pubkey: PublicKey; // voteAccountAddress in v2
   entry: {
-    feeCredit: BN;
-    feeAddress: PublicKey;
+    feeCredit?: BN;
+    feeAddress?: PublicKey;
     stakeSeeds: {
       begin: BN;
       end: BN;
@@ -21,6 +21,7 @@ export interface ValidatorInfo {
     };
     stakeAccountsBalance: BN;
     unstakeAccountsBalance: BN;
+    effectiveStakeBalance?: BN;
     active: BN;
   };
 }
@@ -65,18 +66,19 @@ export interface VaultInfo extends IVaultInfo {
       count: BN;
     };
   };
-  validatorsAccount?: PublicKey;
+  validatorList?: PublicKey;
   validators: {
     entries: ValidatorInfo[];
     maximumEntries: BN;
   };
-  maintainersAccount?: PublicKey;
+  maintainerList?: PublicKey;
   maintainers: {
     entries: {
       pubkey: PublicKey;
     }[];
     maximumEntries: BN;
   };
+  maxCommissionPercentage?: BN;
 }
 
 export interface DepositorInfo extends IDepositorInfo {

--- a/src/lido/infos.ts
+++ b/src/lido/infos.ts
@@ -2,7 +2,7 @@ import { PublicKey, Connection } from "@solana/web3.js";
 import { TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID, AccountLayout } from "@solana/spl-token-v2";
 import { IInstanceVault, IVaultInfoWrapper } from "../types";
 import { LIDO_ADDRESS, LIDO_PROGRAM_ID, ST_SOL_MINT_ADDRESS } from "./ids";
-import { LIDO_LAYOUT } from "./layout";
+import { LIDO_LAYOUT_V1 } from "./layout";
 import * as types from ".";
 import axios from "axios";
 
@@ -35,7 +35,7 @@ infos = class InstanceLido {
 
   static parseVault(data: Buffer, vaultId: PublicKey): types.VaultInfo {
     // Decode the Token data using AccountLayout
-    const decodeData = LIDO_LAYOUT.decode(data);
+    const decodeData = LIDO_LAYOUT_V1.decode(data);
     const {
       lidoVersion,
       manager,

--- a/src/lido/infos.ts
+++ b/src/lido/infos.ts
@@ -126,13 +126,13 @@ export class VaultInfoWrapper implements IVaultInfoWrapper {
   static DEFAULT_APY = "5.74";
   static SOL_API_HOST = "https://sol-api-pub.lido.fi";
 
-  getApr = async () => {
-    const apr: number = await axios.get(`${VaultInfoWrapper.SOL_API_HOST}/v1/apy?since_launch`).then((res) => {
-      return res.data.data.apr;
+  getApy = async () => {
+    const apy: number = await axios.get(`${VaultInfoWrapper.SOL_API_HOST}/v1/apy?since_launch`).then((res) => {
+      return res.data.data.apy;
     });
 
-    if (apr) {
-      return apr.toFixed(2);
+    if (apy) {
+      return apy.toFixed(2);
     }
     return VaultInfoWrapper.DEFAULT_APY;
   };

--- a/src/lido/infos.ts
+++ b/src/lido/infos.ts
@@ -165,7 +165,7 @@ infos = class InstanceLido {
     return {
       depositorId,
       userKey: owner,
-      rawAccount,
+      tokenAccount: rawAccount,
     };
   }
 

--- a/src/lido/infos.ts
+++ b/src/lido/infos.ts
@@ -1,0 +1,28 @@
+import { PublicKey, Connection } from "@solana/web3.js";
+import { IInstanceVault, IVaultInfo, IVaultInfoWrapper } from "../types";
+
+let infos: IInstanceVault;
+
+infos = class InstanceLido {
+  static asymc getAllVaults(connection: Connection): Promise<IVaultInfo[]> {}
+  // TODO: Add wrapper for VaultInfo
+  static async getAllVaultWrappers(connection: Connection): Promise<IVaultInfoWrapper[]> {
+    return (await this.getAllVaults(connection)).map((vault) => new VaultInfoWrapper(vault));
+  }
+  static asymc getVault(connection: Connection, vaultId: PublicKey): Promise<IVaultInfo>;
+  static asymc parseVault(data: Buffer, vaultId: PublicKey): IVaultInfo;
+  static asymc getAllDepositors(connection: Connection, userKey: PublicKey): Promise<IDepositorInfo[]>;
+  static asymc getDepositor(connection: Connection, depositorId: PublicKey, userKey?: PublicKey): Promise<IDepositorInfo>;
+  static asymc getDepositorId(vaultId: PublicKey, userKey: PublicKey, programId?: PublicKey): PublicKey;
+  static asymc getDepositorIdWithBump?(
+    vaultId: PublicKey,
+    userKey: PublicKey,
+    programId?: PublicKey
+  ): { pda: PublicKey; bump: number };
+  static asymc parseDepositor(data: Buffer, depositorId: PublicKey): IDepositorInfo;
+
+  static asymc getWithdrawerId?(vaultId: PublicKey, userKey: PublicKey, programId?: PublicKey): PublicKey;
+  static asymc getWithdrawer?(connection: Connection, withdrawerId: PublicKey, userKey?: PublicKey): Promise<IWithdrawerInfo>;
+  parseWithdrawer?(data: Buffer, withdrawerId: PublicKey): IWithdrawerInfo;
+  getAllWithdrawers?(connection: Connection, userKey: PublicKey): Promise<IWithdrawerInfo[]>;
+};

--- a/src/lido/infos.ts
+++ b/src/lido/infos.ts
@@ -1,28 +1,103 @@
+import { TOKEN_PROGRAM_ID, AccountLayout } from "@solana/spl-token-v2";
 import { PublicKey, Connection } from "@solana/web3.js";
-import { IInstanceVault, IVaultInfo, IVaultInfoWrapper } from "../types";
+import BN from "bn.js";
+import { IInstanceVault, IVaultInfoWrapper } from "../types";
+import { LIDO_ADDRESS, LIDO_PROGRAM_ID, ST_SOL_MINT_ADDRESS } from "./ids";
+import { LIDO_TOKEN_LAYOUT } from "./layout";
+import * as types from ".";
 
 let infos: IInstanceVault;
 
 infos = class InstanceLido {
-  static asymc getAllVaults(connection: Connection): Promise<IVaultInfo[]> {}
-  // TODO: Add wrapper for VaultInfo
-  static async getAllVaultWrappers(connection: Connection): Promise<IVaultInfoWrapper[]> {
+  static async getAllVaults(connection: Connection): Promise<types.VaultInfo[]> {
+    const memcmpFilter = {
+      memcmp: { bytes: ST_SOL_MINT_ADDRESS.toString(), offset: 0 },
+    };
+    const config = {
+      filters: [{ dataSize: 165 }, memcmpFilter],
+    };
+    const accountInfos = await connection.getProgramAccounts(TOKEN_PROGRAM_ID, config);
+    const vaults: types.VaultInfo[] = accountInfos.map((info) => this.parseVault(info.account.data, info.pubkey));
+
+    return vaults;
+  }
+
+  static async getAllVaultWrappers(connection: Connection): Promise<VaultInfoWrapper[]> {
     return (await this.getAllVaults(connection)).map((vault) => new VaultInfoWrapper(vault));
   }
-  static asymc getVault(connection: Connection, vaultId: PublicKey): Promise<IVaultInfo>;
-  static asymc parseVault(data: Buffer, vaultId: PublicKey): IVaultInfo;
-  static asymc getAllDepositors(connection: Connection, userKey: PublicKey): Promise<IDepositorInfo[]>;
-  static asymc getDepositor(connection: Connection, depositorId: PublicKey, userKey?: PublicKey): Promise<IDepositorInfo>;
-  static asymc getDepositorId(vaultId: PublicKey, userKey: PublicKey, programId?: PublicKey): PublicKey;
-  static asymc getDepositorIdWithBump?(
-    vaultId: PublicKey,
-    userKey: PublicKey,
-    programId?: PublicKey
-  ): { pda: PublicKey; bump: number };
-  static asymc parseDepositor(data: Buffer, depositorId: PublicKey): IDepositorInfo;
 
-  static asymc getWithdrawerId?(vaultId: PublicKey, userKey: PublicKey, programId?: PublicKey): PublicKey;
-  static asymc getWithdrawer?(connection: Connection, withdrawerId: PublicKey, userKey?: PublicKey): Promise<IWithdrawerInfo>;
-  parseWithdrawer?(data: Buffer, withdrawerId: PublicKey): IWithdrawerInfo;
-  getAllWithdrawers?(connection: Connection, userKey: PublicKey): Promise<IWithdrawerInfo[]>;
+  static async getVault(connection: Connection, vaultId: PublicKey): Promise<types.VaultInfo> {
+    const vaultAccountInfo = await connection.getAccountInfo(vaultId);
+    if (!vaultAccountInfo) throw Error("Error: Cannot get solido token account");
+
+    const vault: types.VaultInfo = this.parseVault(vaultAccountInfo.data, vaultId);
+
+    return vault;
+  }
+
+  static parseVault(data: Buffer, vaultId: PublicKey): types.VaultInfo {
+    // Decode the Token data using AccountLayout
+    const decodeData = AccountLayout.decode(data);
+    const { mint, amount } = decodeData;
+
+    // Ensure the mint matches
+    if (!this._isAllowed(mint)) {
+      throw Error("Error: Not a stSOL token account");
+    }
+
+    return {
+      vaultId,
+      shareMint: mint,
+      // TODO: Set amount
+      amount: new BN(0),
+    };
+  }
+
+  static async getAllDepositors(connection: Connection, userKey: PublicKey): Promise<types.DepositorInfo[]> {
+    const { value: accountInfos } = await connection.getTokenAccountsByOwner(userKey, {
+      mint: ST_SOL_MINT_ADDRESS,
+    });
+    const depositors = accountInfos.map((depositor) => this.parseDepositor(depositor.account.data, depositor.pubkey));
+    return depositors;
+  }
+
+  static async getDepositor(connection: Connection, depositorId: PublicKey): Promise<types.DepositorInfo> {
+    const depositorAccountInfo = await connection.getAccountInfo(depositorId);
+    if (!depositorAccountInfo) throw Error("Error: Cannot get depositor account");
+
+    return this.parseDepositor(depositorAccountInfo.data, depositorId);
+  }
+
+  static getDepositorId(vaultId: PublicKey, _userKey: PublicKey, _programId: PublicKey = LIDO_PROGRAM_ID): PublicKey {
+    return vaultId;
+  }
+
+  static parseDepositor(data: Buffer, depositorId: PublicKey): types.DepositorInfo {
+    const decodeData = AccountLayout.decode(data);
+    const { mint, owner } = decodeData;
+
+    // Ensure the mint matches
+    if (!this._isAllowed(mint)) {
+      throw Error(`Error: Not a stSOL token account`);
+    }
+
+    return {
+      depositorId,
+      userKey: owner,
+    };
+  }
+  private static _isAllowed(mint: PublicKey): boolean {
+    return mint.equals(ST_SOL_MINT_ADDRESS);
+  }
 };
+
+export { infos };
+
+export class VaultInfoWrapper implements IVaultInfoWrapper {
+  constructor(public vaultInfo: types.VaultInfo) {}
+
+  getApr() {
+    // TODO
+    return 0;
+  }
+}

--- a/src/lido/infos.ts
+++ b/src/lido/infos.ts
@@ -126,7 +126,7 @@ export class VaultInfoWrapper implements IVaultInfoWrapper {
   static DEFAULT_APY = "5.74";
   static SOL_API_HOST = "https://sol-api-pub.lido.fi";
 
-  async getApy(): Promise<string> {
+  static async getApy(): Promise<string> {
     const apy: number = await axios.get(`${VaultInfoWrapper.SOL_API_HOST}/v1/apy?since_launch`).then((res) => {
       return res.data.data.apy;
     });

--- a/src/lido/infos.ts
+++ b/src/lido/infos.ts
@@ -126,7 +126,7 @@ export class VaultInfoWrapper implements IVaultInfoWrapper {
   static DEFAULT_APY = "5.74";
   static SOL_API_HOST = "https://sol-api-pub.lido.fi";
 
-  getApy = async () => {
+  async getApy(): Promise<string> {
     const apy: number = await axios.get(`${VaultInfoWrapper.SOL_API_HOST}/v1/apy?since_launch`).then((res) => {
       return res.data.data.apy;
     });
@@ -135,5 +135,19 @@ export class VaultInfoWrapper implements IVaultInfoWrapper {
       return apy.toFixed(2);
     }
     return VaultInfoWrapper.DEFAULT_APY;
-  };
+  }
+
+  getHeaviestValidator(): types.ValidatorInfo {
+    const validatorEntries = this.vaultInfo.validators.entries;
+    const sortedValidatorEntries = validatorEntries.sort(({ entry: validatorA }, { entry: validatorB }) => {
+      const effectiveStakeBalanceValidatorA =
+        validatorA.stakeAccountsBalance.toNumber() - validatorA.unstakeAccountsBalance.toNumber();
+      const effectiveStakeBalanceValidatorB =
+        validatorB.stakeAccountsBalance.toNumber() - validatorB.unstakeAccountsBalance.toNumber();
+
+      return effectiveStakeBalanceValidatorB - effectiveStakeBalanceValidatorA;
+    });
+
+    return sortedValidatorEntries[0];
+  }
 }

--- a/src/lido/infos.ts
+++ b/src/lido/infos.ts
@@ -1,4 +1,5 @@
 import { PublicKey, Connection } from "@solana/web3.js";
+import { TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID } from "@solana/spl-token-v2";
 import { IInstanceVault, IVaultInfoWrapper } from "../types";
 import { LIDO_ADDRESS, LIDO_PROGRAM_ID, ST_SOL_MINT_ADDRESS } from "./ids";
 import { LIDO_LAYOUT, LIDO_TOKEN_LAYOUT } from "./layout";
@@ -88,8 +89,11 @@ infos = class InstanceLido {
     return this.parseDepositor(depositorAccountInfo.data, depositorId);
   }
 
-  static getDepositorId(vaultId: PublicKey, _userKey: PublicKey, _programId: PublicKey = LIDO_PROGRAM_ID): PublicKey {
-    return vaultId;
+  static getDepositorId(_vaultId: PublicKey, userKey: PublicKey, _programId: PublicKey = LIDO_PROGRAM_ID): PublicKey {
+    return PublicKey.findProgramAddressSync(
+      [userKey.toBuffer(), TOKEN_PROGRAM_ID.toBuffer(), ST_SOL_MINT_ADDRESS.toBuffer()],
+      ASSOCIATED_TOKEN_PROGRAM_ID
+    )[0];
   }
 
   static parseDepositor(data: Buffer, depositorId: PublicKey): types.DepositorInfo {

--- a/src/lido/infos.ts
+++ b/src/lido/infos.ts
@@ -1,8 +1,8 @@
 import { PublicKey, Connection } from "@solana/web3.js";
-import { TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID } from "@solana/spl-token-v2";
+import { TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID, AccountLayout } from "@solana/spl-token-v2";
 import { IInstanceVault, IVaultInfoWrapper } from "../types";
 import { LIDO_ADDRESS, LIDO_PROGRAM_ID, ST_SOL_MINT_ADDRESS } from "./ids";
-import { LIDO_LAYOUT, LIDO_TOKEN_LAYOUT } from "./layout";
+import { LIDO_LAYOUT } from "./layout";
 import * as types from ".";
 
 let infos: IInstanceVault;
@@ -97,9 +97,8 @@ infos = class InstanceLido {
   }
 
   static parseDepositor(data: Buffer, depositorId: PublicKey): types.DepositorInfo {
-    const decodeData = LIDO_TOKEN_LAYOUT.decode(data);
-    const { mint, amount, owner } = decodeData;
-
+    const rawAccount = AccountLayout.decode(data);
+    const { mint, owner } = rawAccount;
     // Ensure the mint matches
     if (!this._isAllowed(mint)) {
       throw Error(`Error: Not a stSOL token account`);
@@ -108,8 +107,7 @@ infos = class InstanceLido {
     return {
       depositorId,
       userKey: owner,
-      amount,
-      mint,
+      rawAccount,
     };
   }
 

--- a/src/lido/infos.ts
+++ b/src/lido/infos.ts
@@ -169,7 +169,7 @@ infos = class InstanceLido {
     };
   }
 
-  static _parseValidatorListAccount(data: Buffer): types.ValidatorAccountInfo {
+  private static _parseValidatorListAccount(data: Buffer): types.ValidatorAccountInfo {
     const decodeData = VALIDATOR_LIST_ACCOUNT_LAYOUT.decode(data);
     const { accountType, lidoVersion, maxEntries, entries } = decodeData;
     if (accountType !== 2 || lidoVersion !== 1) throw Error("Error: Invalid Validator list account");
@@ -214,7 +214,7 @@ infos = class InstanceLido {
     };
   }
 
-  static _parseMaintainerListAccount(data: Buffer): types.MaintainerAccountInfo {
+  private static _parseMaintainerListAccount(data: Buffer): types.MaintainerAccountInfo {
     const decodeData = MAINTAINER_LIST_ACCOUNT_LAYOUT.decode(data);
     const { accountType, lidoVersion, maxEntries, entries } = decodeData;
     if (accountType !== 3 || lidoVersion !== 1) throw Error("Error: Invalid Maintainer list account");

--- a/src/lido/infos.ts
+++ b/src/lido/infos.ts
@@ -4,6 +4,7 @@ import { IInstanceVault, IVaultInfoWrapper } from "../types";
 import { LIDO_ADDRESS, LIDO_PROGRAM_ID, ST_SOL_MINT_ADDRESS } from "./ids";
 import { LIDO_LAYOUT } from "./layout";
 import * as types from ".";
+import axios from "axios";
 
 let infos: IInstanceVault;
 
@@ -121,8 +122,18 @@ export { infos };
 export class VaultInfoWrapper implements IVaultInfoWrapper {
   constructor(public vaultInfo: types.VaultInfo) {}
 
-  getApr() {
-    // TODO
-    return 0;
-  }
+  // See: https://github.com/lidofinance/solido-sdk/blob/main/src/api/stakeApy.ts
+  static DEFAULT_APY = "5.74";
+  static SOL_API_HOST = "https://sol-api-pub.lido.fi";
+
+  getApr = async () => {
+    const apr: number = await axios.get(`${VaultInfoWrapper.SOL_API_HOST}/v1/apy?since_launch`).then((res) => {
+      return res.data.data.apr;
+    });
+
+    if (apr) {
+      return apr.toFixed(2);
+    }
+    return VaultInfoWrapper.DEFAULT_APY;
+  };
 }

--- a/src/lido/layout.ts
+++ b/src/lido/layout.ts
@@ -90,14 +90,14 @@ export const LIDO_LAYOUT_V2 = struct([
 export const VALIDATOR_LIST_ACCOUNT_LAYOUT = struct([
   u8("accountType"),
   u8("lidoVersion"),
-  u8("maxEntries"),
+  u32("maxEntries"),
   vec(VALIDATOR_LAYOUT_V2, "entries"),
 ]);
 
 export const MAINTAINER_LIST_ACCOUNT_LAYOUT = struct([
   u8("accountType"),
   u8("lidoVersion"),
-  u8("maxEntries"),
+  u32("maxEntries"),
   vec(MAINTAINERS_ITEM_LAYOUT, "entries"),
 ]);
 

--- a/src/lido/layout.ts
+++ b/src/lido/layout.ts
@@ -32,7 +32,7 @@ const VALIDATOR_LAYOUT_V1 = struct(
 );
 
 /**
- * Layout of a single validator in Solido V1
+ * Layout of a single validator in Solido V2
  */
 const VALIDATOR_LAYOUT_V2 = struct(
   [
@@ -100,3 +100,6 @@ export const MAINTAINER_LIST_ACCOUNT_LAYOUT = struct([
   u8("maxEntries"),
   vec(MAINTAINERS_ITEM_LAYOUT, "entries"),
 ]);
+
+// A Layout to check if the account being used is a Lido v1 account or a Lido v2 account
+export const LIDO_VERSION_CHECK_LAYOUT = struct([u8("maybeAccountType"), u8("maybeLidoVersion")]);

--- a/src/lido/layout.ts
+++ b/src/lido/layout.ts
@@ -16,7 +16,7 @@ const METRICS_LAYOUT = struct(
 );
 
 /**
- * Layout of a single validator
+ * Layout of a single validator in Solido V1
  */
 const VALIDATOR_LAYOUT_V1 = struct(
   [
@@ -31,7 +31,23 @@ const VALIDATOR_LAYOUT_V1 = struct(
   "entry"
 );
 
-const VALIDATORS_ITEM_LAYOUT = struct([publicKey("pubkey"), VALIDATOR_LAYOUT_V1]);
+/**
+ * Layout of a single validator in Solido V1
+ */
+const VALIDATOR_LAYOUT_V2 = struct(
+  [
+    publicKey("voteAccountAddress"),
+    struct([u64("begin"), u64("end")], "stakeSeeds"),
+    struct([u64("begin"), u64("end")], "unstakeSeeds"),
+    u64("stakeAccountsBalance"),
+    u64("unstakeAccountsBalance"),
+    u64("effectiveAccountsBalance"),
+    u8("active"),
+  ],
+  "entry"
+);
+
+const VALIDATORS_ITEM_LAYOUT_V1 = struct([publicKey("pubkey"), VALIDATOR_LAYOUT_V1]);
 
 const MAINTAINERS_ITEM_LAYOUT = struct([publicKey("pubkey")]);
 
@@ -50,6 +66,37 @@ export const LIDO_LAYOUT_V1 = struct([
   ),
   struct([publicKey("treasuryAccount"), publicKey("developerAccount")], "feeRecipients"),
   METRICS_LAYOUT,
-  struct([vec(VALIDATORS_ITEM_LAYOUT, "entries"), u32("maximumEntries")], "validators"),
+  struct([vec(VALIDATORS_ITEM_LAYOUT_V1, "entries"), u32("maximumEntries")], "validators"),
   struct([vec(MAINTAINERS_ITEM_LAYOUT, "entries"), u32("maximumEntries")], "maintainers"),
+]);
+
+export const LIDO_LAYOUT_V2 = struct([
+  u8("accountType"),
+  u8("lidoVersion"),
+  publicKey("manager"),
+  publicKey("stSolMint"),
+  struct([u64("computedInEpoch"), u64("stSolSupply"), u64("solBalance")], "exchangeRate"),
+  u8("solReserveAuthorityBumpSeed"),
+  u8("stakeAuthorityBumpSeed"),
+  u8("mintAuthorityBumpSeed"),
+  struct([u32("treasuryFee"), u32("developerFee"), u32("stSolAppreciation")], "rewardDistribution"),
+  struct([publicKey("treasuryAccount"), publicKey("developerAccount")], "feeRecipients"),
+  METRICS_LAYOUT,
+  publicKey("validatorList"),
+  publicKey("maintainerList"),
+  u8("maxCommissionPercentage"),
+]);
+
+export const VALIDATOR_LIST_ACCOUNT_LAYOUT = struct([
+  u8("accountType"),
+  u8("lidoVersion"),
+  u8("maxEntries"),
+  vec(VALIDATOR_LAYOUT_V2, "entries"),
+]);
+
+export const MAINTAINER_LIST_ACCOUNT_LAYOUT = struct([
+  u8("accountType"),
+  u8("lidoVersion"),
+  u8("maxEntries"),
+  vec(MAINTAINERS_ITEM_LAYOUT, "entries"),
 ]);

--- a/src/lido/layout.ts
+++ b/src/lido/layout.ts
@@ -16,24 +16,14 @@ const METRICS_LAYOUT = struct(
 );
 
 /**
- * Seed range with a begin and end, both u64
- *
- * @param property optional name for the seed range
- * @returns (named) struct containing a seed range
- */
-function seedRange(property?: string | undefined): struct {
-  return struct([u64("begin"), u64("end")], property);
-}
-
-/**
  * Layout of a single validator
  */
 const VALIDATOR_LAYOUT = struct(
   [
     u64("feeCredit"),
     publicKey("feeAddress"),
-    seedRange("stakeSeeds"),
-    seedRange("unstakeSeeds"),
+    struct([u64("begin"), u64("end")], "stakeSeeds"),
+    struct([u64("begin"), u64("end")], "unstakeSeeds"),
     u64("stakeAccountsBalance"),
     u64("unstakeAccountsBalance"),
     u8("active"),

--- a/src/lido/layout.ts
+++ b/src/lido/layout.ts
@@ -1,0 +1,83 @@
+import { publicKey, struct, u64, u8, u32, array, vec } from "@project-serum/borsh";
+
+const METRICS_LAYOUT = struct(
+  [
+    u64("feeTreasurySolTotal"),
+    u64("feeValidationSolTotal"),
+    u64("feeDeveloperSolTotal"),
+    u64("stSolAppreciationTotal"),
+    u64("feeTreasuryStSolTotal"),
+    u64("feeValidationStSolTotal"),
+    u64("feeDeveloperStSolTotal"),
+    struct([array(u64(), 12, "counts"), u64("total")], "depositAmount"),
+    struct([u64("totalStSolAmount"), u64("totalSolAmount"), u64("count")], "withdrawAmount"),
+  ],
+  "metrics"
+);
+
+/**
+ * Seed range with a begin and end, both u64
+ *
+ * @param property optional name for the seed range
+ * @returns (named) struct containing a seed range
+ */
+function seedRange(property?: string | undefined): struct {
+  return struct([u64("begin"), u64("end")], property);
+}
+
+/**
+ * Layout of a single validator
+ */
+const VALIDATOR_LAYOUT = struct(
+  [
+    u64("feeCredit"),
+    publicKey("feeAddress"),
+    seedRange("stakeSeeds"),
+    seedRange("unstakeSeeds"),
+    u64("stakeAccountsBalance"),
+    u64("unstakeAccountsBalance"),
+    u8("active"),
+  ],
+  "entry"
+);
+
+const VALIDATORS_ITEM_LAYOUT = struct([publicKey("pubkey"), VALIDATOR_LAYOUT]);
+
+// TODO: Review the [0] part
+const MAINTAINERS_ITEM_LAYOUT = struct([publicKey("pubkey"), [0]]);
+
+// TODO: Check use of vec here, and if something else is more appropriate here
+export const LIDO_LAYOUT = struct([
+  u8("lidoVersion"),
+  publicKey("manager"),
+  publicKey("stSolMint"),
+  struct([u64("computedInEpoch"), u64("stSolSupply"), u64("solBalance")], "exchangeRate"),
+  u8("solReserveAuthorityBumpSeed"),
+  u8("stakeAuthorityBumpSeed"),
+  u8("mintAuthorityBumpSeed"),
+  u8("rewardsWithdrawAuthorityBumpSeed"),
+  struct(
+    [u32("treasuryFee"), u32("validationFee"), u32("developerFee"), u32("stSolAppreciation")],
+    "rewardDistribution"
+  ),
+  struct([publicKey("treasuryAccount"), publicKey("developerAccount"), "feeRecipients"]),
+  METRICS_LAYOUT,
+  struct([vec(VALIDATORS_ITEM_LAYOUT, "entries"), u32("maximumEntries")], "validators"),
+  struct([vec(MAINTAINERS_ITEM_LAYOUT, "entries"), u32("maximumEntries")], "maintainers"),
+]);
+
+// TODO: Use LIDO_TOKEN_LAYOUT
+// See: https://github.com/solana-labs/solana-program-library/issues/2683
+export const LIDO_TOKEN_LAYOUT = struct([
+  publicKey("mint"),
+  publicKey("owner"),
+  u64("amount"),
+  u8("delegateOption"),
+  publicKey("delegate"),
+  u8("state"),
+  u8("isNativeOption"),
+  u64("isNative"),
+  u64("delegatedAmount"),
+  u8("closeAuthorityOption"),
+  publicKey("closeAuthority"),
+]);

--- a/src/lido/layout.ts
+++ b/src/lido/layout.ts
@@ -53,17 +53,3 @@ export const LIDO_LAYOUT = struct([
   struct([vec(VALIDATORS_ITEM_LAYOUT, "entries"), u32("maximumEntries")], "validators"),
   struct([vec(MAINTAINERS_ITEM_LAYOUT, "entries"), u32("maximumEntries")], "maintainers"),
 ]);
-
-export const LIDO_TOKEN_LAYOUT = struct([
-  publicKey("mint"),
-  publicKey("owner"),
-  u64("amount"),
-  u8("delegateOption"),
-  publicKey("delegate"),
-  u8("state"),
-  u8("isNativeOption"),
-  u64("isNative"),
-  u64("delegatedAmount"),
-  u8("closeAuthorityOption"),
-  publicKey("closeAuthority"),
-]);

--- a/src/lido/layout.ts
+++ b/src/lido/layout.ts
@@ -18,7 +18,7 @@ const METRICS_LAYOUT = struct(
 /**
  * Layout of a single validator
  */
-const VALIDATOR_LAYOUT = struct(
+const VALIDATOR_LAYOUT_V1 = struct(
   [
     u64("feeCredit"),
     publicKey("feeAddress"),
@@ -31,11 +31,11 @@ const VALIDATOR_LAYOUT = struct(
   "entry"
 );
 
-const VALIDATORS_ITEM_LAYOUT = struct([publicKey("pubkey"), VALIDATOR_LAYOUT]);
+const VALIDATORS_ITEM_LAYOUT = struct([publicKey("pubkey"), VALIDATOR_LAYOUT_V1]);
 
 const MAINTAINERS_ITEM_LAYOUT = struct([publicKey("pubkey")]);
 
-export const LIDO_LAYOUT = struct([
+export const LIDO_LAYOUT_V1 = struct([
   u8("lidoVersion"),
   publicKey("manager"),
   publicKey("stSolMint"),

--- a/src/lido/layout.ts
+++ b/src/lido/layout.ts
@@ -43,10 +43,8 @@ const VALIDATOR_LAYOUT = struct(
 
 const VALIDATORS_ITEM_LAYOUT = struct([publicKey("pubkey"), VALIDATOR_LAYOUT]);
 
-// TODO: Review the [0] part
-const MAINTAINERS_ITEM_LAYOUT = struct([publicKey("pubkey"), [0]]);
+const MAINTAINERS_ITEM_LAYOUT = struct([publicKey("pubkey")]);
 
-// TODO: Check use of vec here, and if something else is more appropriate here
 export const LIDO_LAYOUT = struct([
   u8("lidoVersion"),
   publicKey("manager"),
@@ -60,14 +58,12 @@ export const LIDO_LAYOUT = struct([
     [u32("treasuryFee"), u32("validationFee"), u32("developerFee"), u32("stSolAppreciation")],
     "rewardDistribution"
   ),
-  struct([publicKey("treasuryAccount"), publicKey("developerAccount"), "feeRecipients"]),
+  struct([publicKey("treasuryAccount"), publicKey("developerAccount")], "feeRecipients"),
   METRICS_LAYOUT,
   struct([vec(VALIDATORS_ITEM_LAYOUT, "entries"), u32("maximumEntries")], "validators"),
   struct([vec(MAINTAINERS_ITEM_LAYOUT, "entries"), u32("maximumEntries")], "maintainers"),
 ]);
 
-// TODO: Use LIDO_TOKEN_LAYOUT
-// See: https://github.com/solana-labs/solana-program-library/issues/2683
 export const LIDO_TOKEN_LAYOUT = struct([
   publicKey("mint"),
   publicKey("owner"),

--- a/test/lido.ts
+++ b/test/lido.ts
@@ -10,50 +10,56 @@ describe("Lido", () => {
   //TODO: Modify these addresses
   const userKey = new PublicKey("Dkx85wVaUaDy9i9XWFdZvYrw5h2WMP1N8TqXPBdXY5Wh");
   const tokenKey = new PublicKey("F9kWLTs28mWKmmvKDhAvtHuVwYKx6L4yG7C3n4WyLVh6");
-  // it(" Can get all vaults", async () => {
-  //   const vaults = (await lido.infos.getAllVaults(connection)) as lido.VaultInfo[];
+  it(" Can get all vaults", async () => {
+    const vaults = (await lido.infos.getAllVaults(connection)) as lido.VaultInfo[];
 
-  //   // Should only return main Lido Account information
-  //   assert(vaults.length == 1);
+    // Should only return main Lido Account information
+    assert(vaults.length == 1);
 
-  //   console.log(`- Fetched ${vaults.length} vault`);
-  // });
-  // it(" Can get vault", async () => {
-  //   const vault = await lido.infos.getVault!(connection, lido.LIDO_ADDRESS);
-  //   console.log(`- VaultId: ${vault.vaultId.toBase58()}`);
-  //   console.log(`- Vault shareMint: ${vault.shareMint.toBase58()}`);
-  // });
-  // it(" Can get all depositors", async () => {
-  //   const depositors = (await lido.infos.getAllDepositors(connection, userKey)) as lido.DepositorInfo[];
-  //   console.log(`Fetched ${depositors.length} depositors`);
-  //   depositors.forEach((d, i) => {
-  //     console.log(`\n* Depositor #${i + 1}`);
-  //     console.log(`** DepositorId: ${d.depositorId}`);
-  //     console.log(`** Deposited Balance: ${d.rawAccount.amount}`);
-  //   });
-  // });
-  // it(" Can get depositor", async () => {
-  //   const depositor = (await lido.infos.getDepositor(connection, tokenKey)) as lido.DepositorInfo;
-  //   console.log(`- Deposited Balance: ${depositor.rawAccount.amount}`);
-  //   console.log(`- Owner: ${depositor.userKey.toBase58()}`);
-  // });
-  // it(" Can get maintainers", async () => {
-  //   const vault = (await lido.infos.getVault(connection, lido.LIDO_ADDRESS)) as lido.VaultInfo;
-  //   vault.maintainers.entries.forEach((m, i) => {
-  //     console.log(`\n* Maintainer #${i + 1}`);
-  //     console.log(`** Maintainer Pubkey: ${m.pubkey.toBase58()}`);
-  //   });
-  // });
-  // it(" Can get validators", async () => {
-  //   const vault = (await lido.infos.getVault(connection, lido.LIDO_ADDRESS)) as lido.VaultInfo;
-  //   vault.validators.entries.forEach((v, i) => {
-  //     console.log(`\n* Validator #${i + 1}`);
-  //     console.log(`** Validator Pubkey: ${v.pubkey.toBase58()}`);
-  //   });
-  // });
-  it(" Can get APR", async () => {
+    console.log(`- Fetched ${vaults.length} vault`);
+  });
+  it(" Can get vault", async () => {
+    const vault = await lido.infos.getVault!(connection, lido.LIDO_ADDRESS);
+    console.log(`- VaultId: ${vault.vaultId.toBase58()}`);
+    console.log(`- Vault shareMint: ${vault.shareMint.toBase58()}`);
+  });
+  it(" Can get all depositors", async () => {
+    const depositors = (await lido.infos.getAllDepositors(connection, userKey)) as lido.DepositorInfo[];
+    console.log(`Fetched ${depositors.length} depositors`);
+    depositors.forEach((d, i) => {
+      console.log(`\n* Depositor #${i + 1}`);
+      console.log(`** DepositorId: ${d.depositorId}`);
+      console.log(`** Deposited Balance: ${d.rawAccount.amount}`);
+    });
+  });
+  it(" Can get depositor", async () => {
+    const depositor = (await lido.infos.getDepositor(connection, tokenKey)) as lido.DepositorInfo;
+    console.log(`- Deposited Balance: ${depositor.rawAccount.amount}`);
+    console.log(`- Owner: ${depositor.userKey.toBase58()}`);
+  });
+  it(" Can get maintainers", async () => {
     const vault = (await lido.infos.getVault(connection, lido.LIDO_ADDRESS)) as lido.VaultInfo;
-    const vaultWrapper = new lido.VaultInfoWrapper(vault);
-    console.log(await vaultWrapper.getApy());
+    vault.maintainers.entries.forEach((m, i) => {
+      console.log(`\n* Maintainer #${i + 1}`);
+      console.log(`** Maintainer Pubkey: ${m.pubkey.toBase58()}`);
+    });
+  });
+  it(" Can get validators", async () => {
+    const vault = (await lido.infos.getVault(connection, lido.LIDO_ADDRESS)) as lido.VaultInfo;
+    vault.validators.entries.forEach((v, i) => {
+      console.log(`\n* Validator #${i + 1}`);
+      console.log(`** Validator Pubkey: ${v.pubkey.toBase58()}`);
+    });
+  });
+  it(" Can get heaviest validator", async () => {
+    const vault = new lido.VaultInfoWrapper(
+      (await lido.infos.getVault(connection, lido.LIDO_ADDRESS)) as lido.VaultInfo
+    );
+    const heaviestValidator = vault.getHeaviestValidator();
+    console.log(`- Heaviest Validator: ${heaviestValidator.pubkey.toBase58()}`);
+    console.log(`- Heaviest Validator Balance: ${heaviestValidator.entry.stakeAccountsBalance.toString()}`);
+  });
+  it(" Can get APY", async () => {
+    console.log(await lido.VaultInfoWrapper.getApy());
   });
 });

--- a/test/lido.ts
+++ b/test/lido.ts
@@ -7,9 +7,17 @@ describe("Lido", () => {
     commitment: "confirmed",
     confirmTransactionInitialTimeout: 180 * 1000,
   });
+
+  // Use Testnet
+  // const connection = new Connection("https://api.testnet.solana.com", {
+  //   commitment: "confirmed",
+  //   confirmTransactionInitialTimeout: 180 * 1000,
+  // });
+
   //TODO: Modify these addresses
   const userKey = new PublicKey("Dkx85wVaUaDy9i9XWFdZvYrw5h2WMP1N8TqXPBdXY5Wh");
   const tokenKey = new PublicKey("F9kWLTs28mWKmmvKDhAvtHuVwYKx6L4yG7C3n4WyLVh6");
+
   it(" Can get Version", async () => {
     const vault = (await lido.infos.getVault!(connection, lido.LIDO_ADDRESS)) as lido.VaultInfo;
     const vaultInfoWrapper = new lido.VaultInfoWrapper(vault);

--- a/test/lido.ts
+++ b/test/lido.ts
@@ -24,17 +24,17 @@ describe("Lido", () => {
     console.log(`- Vault shareMint: ${vault.shareMint.toBase58()}`);
   });
   it(" Can get all depositors", async () => {
-    const depositors = await lido.infos.getAllDepositors(connection, userKey) as lido.DepositorInfo[];
+    const depositors = (await lido.infos.getAllDepositors(connection, userKey)) as lido.DepositorInfo[];
     console.log(`Fetched ${depositors.length} depositors`);
     depositors.forEach((d, i) => {
       console.log(`\n* Depositor #${i + 1}`);
       console.log(`** DepositorId: ${d.depositorId}`);
-      console.log(`** Deposited Balance: ${d.amount.toNumber()}`);
+      console.log(`** Deposited Balance: ${d.rawAccount.amount}`);
     });
   });
   it(" Can get depositor", async () => {
-    const depositor = await lido.infos.getDepositor(connection, tokenKey) as lido.DepositorInfo;
-    console.log(`- Deposited Balance: ${depositor.amount.toNumber()}`);
+    const depositor = (await lido.infos.getDepositor(connection, tokenKey)) as lido.DepositorInfo;
+    console.log(`- Deposited Balance: ${depositor.rawAccount.amount}`);
     console.log(`- Owner: ${depositor.userKey.toBase58()}`);
   });
   it(" Can get maintainers", async () => {

--- a/test/lido.ts
+++ b/test/lido.ts
@@ -22,20 +22,19 @@ describe("Lido", () => {
     const vault = await lido.infos.getVault!(connection, lido.LIDO_ADDRESS);
     console.log(`- VaultId: ${vault.vaultId.toBase58()}`);
     console.log(`- Vault shareMint: ${vault.shareMint.toBase58()}`);
-    // console.log(`- Vault base PDA: ${vault.base.pda.toBase58()}`);
   });
   it(" Can get all depositors", async () => {
-    const depositors = await lido.infos.getAllDepositors(connection, userKey);
+    const depositors = await lido.infos.getAllDepositors(connection, userKey) as lido.DepositorInfo[];
     console.log(`Fetched ${depositors.length} depositors`);
     depositors.forEach((d, i) => {
       console.log(`\n* Depositor #${i + 1}`);
       console.log(`** DepositorId: ${d.depositorId}`);
-      //   console.log(`** Deposited Balance: ${d.amount.toNumber()}`);
+      console.log(`** Deposited Balance: ${d.amount.toNumber()}`);
     });
   });
   it(" Can get depositor", async () => {
-    const depositor = await lido.infos.getDepositor(connection, tokenKey);
-    // console.log(`- Deposited Balance: ${depositor.depositedBalance.toNumber()}`);
+    const depositor = await lido.infos.getDepositor(connection, tokenKey) as lido.DepositorInfo;
+    console.log(`- Deposited Balance: ${depositor.amount.toNumber()}`);
     console.log(`- Owner: ${depositor.userKey.toBase58()}`);
   });
   it(" Can get maintainers", async () => {

--- a/test/lido.ts
+++ b/test/lido.ts
@@ -10,45 +10,50 @@ describe("Lido", () => {
   //TODO: Modify these addresses
   const userKey = new PublicKey("Dkx85wVaUaDy9i9XWFdZvYrw5h2WMP1N8TqXPBdXY5Wh");
   const tokenKey = new PublicKey("F9kWLTs28mWKmmvKDhAvtHuVwYKx6L4yG7C3n4WyLVh6");
-  it(" Can get all vaults", async () => {
-    const vaults = (await lido.infos.getAllVaults(connection)) as lido.VaultInfo[];
+  // it(" Can get all vaults", async () => {
+  //   const vaults = (await lido.infos.getAllVaults(connection)) as lido.VaultInfo[];
 
-    // Should only return main Lido Account information
-    assert(vaults.length == 1);
+  //   // Should only return main Lido Account information
+  //   assert(vaults.length == 1);
 
-    console.log(`- Fetched ${vaults.length} vault`);
-  });
-  it(" Can get vault", async () => {
-    const vault = await lido.infos.getVault!(connection, lido.LIDO_ADDRESS);
-    console.log(`- VaultId: ${vault.vaultId.toBase58()}`);
-    console.log(`- Vault shareMint: ${vault.shareMint.toBase58()}`);
-  });
-  it(" Can get all depositors", async () => {
-    const depositors = (await lido.infos.getAllDepositors(connection, userKey)) as lido.DepositorInfo[];
-    console.log(`Fetched ${depositors.length} depositors`);
-    depositors.forEach((d, i) => {
-      console.log(`\n* Depositor #${i + 1}`);
-      console.log(`** DepositorId: ${d.depositorId}`);
-      console.log(`** Deposited Balance: ${d.rawAccount.amount}`);
-    });
-  });
-  it(" Can get depositor", async () => {
-    const depositor = (await lido.infos.getDepositor(connection, tokenKey)) as lido.DepositorInfo;
-    console.log(`- Deposited Balance: ${depositor.rawAccount.amount}`);
-    console.log(`- Owner: ${depositor.userKey.toBase58()}`);
-  });
-  it(" Can get maintainers", async () => {
+  //   console.log(`- Fetched ${vaults.length} vault`);
+  // });
+  // it(" Can get vault", async () => {
+  //   const vault = await lido.infos.getVault!(connection, lido.LIDO_ADDRESS);
+  //   console.log(`- VaultId: ${vault.vaultId.toBase58()}`);
+  //   console.log(`- Vault shareMint: ${vault.shareMint.toBase58()}`);
+  // });
+  // it(" Can get all depositors", async () => {
+  //   const depositors = (await lido.infos.getAllDepositors(connection, userKey)) as lido.DepositorInfo[];
+  //   console.log(`Fetched ${depositors.length} depositors`);
+  //   depositors.forEach((d, i) => {
+  //     console.log(`\n* Depositor #${i + 1}`);
+  //     console.log(`** DepositorId: ${d.depositorId}`);
+  //     console.log(`** Deposited Balance: ${d.rawAccount.amount}`);
+  //   });
+  // });
+  // it(" Can get depositor", async () => {
+  //   const depositor = (await lido.infos.getDepositor(connection, tokenKey)) as lido.DepositorInfo;
+  //   console.log(`- Deposited Balance: ${depositor.rawAccount.amount}`);
+  //   console.log(`- Owner: ${depositor.userKey.toBase58()}`);
+  // });
+  // it(" Can get maintainers", async () => {
+  //   const vault = (await lido.infos.getVault(connection, lido.LIDO_ADDRESS)) as lido.VaultInfo;
+  //   vault.maintainers.entries.forEach((m, i) => {
+  //     console.log(`\n* Maintainer #${i + 1}`);
+  //     console.log(`** Maintainer Pubkey: ${m.pubkey.toBase58()}`);
+  //   });
+  // });
+  // it(" Can get validators", async () => {
+  //   const vault = (await lido.infos.getVault(connection, lido.LIDO_ADDRESS)) as lido.VaultInfo;
+  //   vault.validators.entries.forEach((v, i) => {
+  //     console.log(`\n* Validator #${i + 1}`);
+  //     console.log(`** Validator Pubkey: ${v.pubkey.toBase58()}`);
+  //   });
+  // });
+  it(" Can get APR", async () => {
     const vault = (await lido.infos.getVault(connection, lido.LIDO_ADDRESS)) as lido.VaultInfo;
-    vault.maintainers.entries.forEach((m, i) => {
-      console.log(`\n* Maintainer #${i + 1}`);
-      console.log(`** Maintainer Pubkey: ${m.pubkey.toBase58()}`);
-    });
-  });
-  it(" Can get validators", async () => {
-    const vault = (await lido.infos.getVault(connection, lido.LIDO_ADDRESS)) as lido.VaultInfo;
-    vault.validators.entries.forEach((v, i) => {
-      console.log(`\n* Validator #${i + 1}`);
-      console.log(`** Validator Pubkey: ${v.pubkey.toBase58()}`);
-    });
+    const vaultWrapper = new lido.VaultInfoWrapper(vault);
+    console.log(await vaultWrapper.getApr());
   });
 });

--- a/test/lido.ts
+++ b/test/lido.ts
@@ -1,4 +1,5 @@
 import { Connection, PublicKey } from "@solana/web3.js";
+import { assert } from "console";
 import * as lido from "../src/lido";
 
 describe("Lido", () => {
@@ -11,10 +12,14 @@ describe("Lido", () => {
   const tokenKey = new PublicKey("F9kWLTs28mWKmmvKDhAvtHuVwYKx6L4yG7C3n4WyLVh6");
   it(" Can get all vaults", async () => {
     const vaults = (await lido.infos.getAllVaults(connection)) as lido.VaultInfo[];
-    console.log(`- Fetched ${vaults.length} vaults`);
+
+    // Should only return main Lido Account information
+    assert(vaults.length == 1);
+
+    console.log(`- Fetched ${vaults.length} vault`);
   });
   it(" Can get vault", async () => {
-    const vault = await lido.infos.getVault!(connection, tokenKey);
+    const vault = await lido.infos.getVault!(connection, lido.LIDO_ADDRESS);
     console.log(`- VaultId: ${vault.vaultId.toBase58()}`);
     console.log(`- Vault shareMint: ${vault.shareMint.toBase58()}`);
     // console.log(`- Vault base PDA: ${vault.base.pda.toBase58()}`);
@@ -32,5 +37,19 @@ describe("Lido", () => {
     const depositor = await lido.infos.getDepositor(connection, tokenKey);
     // console.log(`- Deposited Balance: ${depositor.depositedBalance.toNumber()}`);
     console.log(`- Owner: ${depositor.userKey.toBase58()}`);
+  });
+  it(" Can get maintainers", async () => {
+    const vault = (await lido.infos.getVault(connection, lido.LIDO_ADDRESS)) as lido.VaultInfo;
+    vault.maintainers.entries.forEach((m, i) => {
+      console.log(`\n* Maintainer #${i + 1}`);
+      console.log(`** Maintainer Pubkey: ${m.pubkey.toBase58()}`);
+    });
+  });
+  it(" Can get validators", async () => {
+    const vault = (await lido.infos.getVault(connection, lido.LIDO_ADDRESS)) as lido.VaultInfo;
+    vault.validators.entries.forEach((v, i) => {
+      console.log(`\n* Validator #${i + 1}`);
+      console.log(`** Validator Pubkey: ${v.pubkey.toBase58()}`);
+    });
   });
 });

--- a/test/lido.ts
+++ b/test/lido.ts
@@ -1,0 +1,36 @@
+import { Connection, PublicKey } from "@solana/web3.js";
+import * as lido from "../src/lido";
+
+describe("Lido", () => {
+  const connection = new Connection("https://api.mainnet-beta.solana.com", {
+    commitment: "confirmed",
+    confirmTransactionInitialTimeout: 180 * 1000,
+  });
+  //TODO: Modify these addresses
+  const userKey = new PublicKey("Dkx85wVaUaDy9i9XWFdZvYrw5h2WMP1N8TqXPBdXY5Wh");
+  const tokenKey = new PublicKey("F9kWLTs28mWKmmvKDhAvtHuVwYKx6L4yG7C3n4WyLVh6");
+  it(" Can get all vaults", async () => {
+    const vaults = (await lido.infos.getAllVaults(connection)) as lido.VaultInfo[];
+    console.log(`- Fetched ${vaults.length} vaults`);
+  });
+  it(" Can get vault", async () => {
+    const vault = await lido.infos.getVault!(connection, tokenKey);
+    console.log(`- VaultId: ${vault.vaultId.toBase58()}`);
+    console.log(`- Vault shareMint: ${vault.shareMint.toBase58()}`);
+    // console.log(`- Vault base PDA: ${vault.base.pda.toBase58()}`);
+  });
+  it(" Can get all depositors", async () => {
+    const depositors = await lido.infos.getAllDepositors(connection, userKey);
+    console.log(`Fetched ${depositors.length} depositors`);
+    depositors.forEach((d, i) => {
+      console.log(`\n* Depositor #${i + 1}`);
+      console.log(`** DepositorId: ${d.depositorId}`);
+      //   console.log(`** Deposited Balance: ${d.amount.toNumber()}`);
+    });
+  });
+  it(" Can get depositor", async () => {
+    const depositor = await lido.infos.getDepositor(connection, tokenKey);
+    // console.log(`- Deposited Balance: ${depositor.depositedBalance.toNumber()}`);
+    console.log(`- Owner: ${depositor.userKey.toBase58()}`);
+  });
+});

--- a/test/lido.ts
+++ b/test/lido.ts
@@ -42,12 +42,12 @@ describe("Lido", () => {
     depositors.forEach((d, i) => {
       console.log(`\n* Depositor #${i + 1}`);
       console.log(`** DepositorId: ${d.depositorId}`);
-      console.log(`** Deposited Balance: ${d.rawAccount.amount}`);
+      console.log(`** Deposited Balance: ${d.tokenAccount.amount}`);
     });
   });
   it(" Can get depositor", async () => {
     const depositor = (await lido.infos.getDepositor(connection, tokenKey)) as lido.DepositorInfo;
-    console.log(`- Deposited Balance: ${depositor.rawAccount.amount}`);
+    console.log(`- Deposited Balance: ${depositor.tokenAccount.amount}`);
     console.log(`- Owner: ${depositor.userKey.toBase58()}`);
   });
   it(" Can get maintainers", async () => {

--- a/test/lido.ts
+++ b/test/lido.ts
@@ -54,6 +54,6 @@ describe("Lido", () => {
   it(" Can get APR", async () => {
     const vault = (await lido.infos.getVault(connection, lido.LIDO_ADDRESS)) as lido.VaultInfo;
     const vaultWrapper = new lido.VaultInfoWrapper(vault);
-    console.log(await vaultWrapper.getApr());
+    console.log(await vaultWrapper.getApy());
   });
 });

--- a/test/lido.ts
+++ b/test/lido.ts
@@ -10,6 +10,11 @@ describe("Lido", () => {
   //TODO: Modify these addresses
   const userKey = new PublicKey("Dkx85wVaUaDy9i9XWFdZvYrw5h2WMP1N8TqXPBdXY5Wh");
   const tokenKey = new PublicKey("F9kWLTs28mWKmmvKDhAvtHuVwYKx6L4yG7C3n4WyLVh6");
+  it(" Can get Version", async () => {
+    const vault = (await lido.infos.getVault!(connection, lido.LIDO_ADDRESS)) as lido.VaultInfo;
+    const vaultInfoWrapper = new lido.VaultInfoWrapper(vault);
+    console.log(`- Solido Version: ${vaultInfoWrapper.getVersion()}`);
+  });
   it(" Can get all vaults", async () => {
     const vaults = (await lido.infos.getAllVaults(connection)) as lido.VaultInfo[];
 
@@ -39,14 +44,14 @@ describe("Lido", () => {
   });
   it(" Can get maintainers", async () => {
     const vault = (await lido.infos.getVault(connection, lido.LIDO_ADDRESS)) as lido.VaultInfo;
-    vault.maintainers.entries.forEach((m, i) => {
+    vault.maintainers!.entries.forEach((m, i) => {
       console.log(`\n* Maintainer #${i + 1}`);
       console.log(`** Maintainer Pubkey: ${m.pubkey.toBase58()}`);
     });
   });
   it(" Can get validators", async () => {
     const vault = (await lido.infos.getVault(connection, lido.LIDO_ADDRESS)) as lido.VaultInfo;
-    vault.validators.entries.forEach((v, i) => {
+    vault.validators!.entries.forEach((v, i) => {
       console.log(`\n* Validator #${i + 1}`);
       console.log(`** Validator Pubkey: ${v.pubkey.toBase58()}`);
     });

--- a/test/lido.ts
+++ b/test/lido.ts
@@ -60,6 +60,6 @@ describe("Lido", () => {
     console.log(`- Heaviest Validator Balance: ${heaviestValidator.entry.stakeAccountsBalance.toString()}`);
   });
   it(" Can get APY", async () => {
-    console.log(await lido.VaultInfoWrapper.getApy());
+    console.log(`- APY: ${await lido.VaultInfoWrapper.getApy()}%`);
   });
 });

--- a/test/lido.ts
+++ b/test/lido.ts
@@ -8,12 +8,6 @@ describe("Lido", () => {
     confirmTransactionInitialTimeout: 180 * 1000,
   });
 
-  // Use Testnet
-  // const connection = new Connection("https://api.testnet.solana.com", {
-  //   commitment: "confirmed",
-  //   confirmTransactionInitialTimeout: 180 * 1000,
-  // });
-
   //TODO: Modify these addresses
   const userKey = new PublicKey("Dkx85wVaUaDy9i9XWFdZvYrw5h2WMP1N8TqXPBdXY5Wh");
   const tokenKey = new PublicKey("F9kWLTs28mWKmmvKDhAvtHuVwYKx6L4yG7C3n4WyLVh6");


### PR DESCRIPTION
I worked on the assigned task on including Lido Finance as a Navigator, and have completed an initial implemention that I would like to pass on to review.

A summary of my changes are as follows:

- Added a folder called ```lido``` to the ```src``` directory.
- Added lido implementation inside said folder.
- Added a test file in the ```test``` folder, with 4 tests.
- Ensured all 4/4 tests pass.
- Added an export to ```src/index.ts``` for lido.
- Modified ```package.json``` to include test for lido.

Things that need to be worked on further:
- VaultInfo and DepositorInfo are currently shells around IVaultInfo and IDepositorInfo, respectively.
- There is an error I faced with a custom layout: [Solana Program Library Issue #2683](https://github.com/solana-labs/solana-program-library/issues/2683), which would require us to update the version of the Solana web3 library being used.
- An issue with the current implementation of Lido being possibly incompatible with the other DeFi protocols due to a mismatch in numeric type (bigint vs BN).
- Review of the ```LIDO_LAYOUT```, which is not currently being used, but could be useful to get/store data regarding stSOL.
- Addresses used while testing are actual addresses picked randomly. I am unsure of the best practice here.
