### PR TITLE
feat: optimize getMultipleAccounts

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -139,6 +139,12 @@ export async function getMultipleAccounts(
     account: AccountInfo<Buffer> | null;
   }[]
 > {
+  const chunks = (array: PublicKey[], size: number) => {
+    return Array.apply(0, new Array(Math.ceil(array.length / size))).map((_, index) =>
+      array.slice(index * size, (index + 1) * size)
+    );
+  };
+
   interface RPCResult {
     jsonrpc: string;
     result: {
@@ -196,10 +202,4 @@ export async function getMultipleAccounts(
       account: res,
     };
   });
-}
-
-function chunks(array: PublicKey[], size: number) {
-  return Array.apply(0, new Array(Math.ceil(array.length / size))).map((_, index) =>
-    array.slice(index * size, (index + 1) * size)
-  );
 }

--- a/test/orca.ts
+++ b/test/orca.ts
@@ -57,10 +57,10 @@ describe("Orca", () => {
     console.log("# of farms:", farms.length);
 
     farms.forEach((farm) => {
-      const apr = farm.getApr();
-      const doubleDipApr = farm.getApr(true);
+      const apr = farm.getAprs(0, 0, 0);
+      const doubleDipApr = farm.getAprs(0, 0, 0, true);
 
-      if (apr || doubleDipApr) {
+      if ((apr || doubleDipApr) && farm.farmInfo.poolId) {
         let pool = pools.find((item) => item.poolId.equals(farm.farmInfo.poolId!));
         let tokenA = tokenList.find((t) => t.mint === pool?.tokenAMint.toBase58());
         let tokenB = tokenList.find((t) => t.mint === pool?.tokenBMint.toBase58());


### PR DESCRIPTION
- Update `getMultipleAccounts` in `utils` by using web3.js internal function `_rpcBatchRequest()` to fetch multiple accounts at once.