### PR TITLE
Fix lifinity getAllPools

### DIFF
--- a/src/lifinity/infos.ts
+++ b/src/lifinity/infos.ts
@@ -61,7 +61,9 @@ infos = class InstanceLifinity {
         mintB = tokenList.find((t) => t.symbol === symbolB);
         tokenMap.set(symbolB, mintB!);
       }
-      poolMap.set(mintA!.mint.concat(mintB!.mint), data);
+      if (mintA && mintB) {
+        poolMap.set(mintA!.mint.concat(mintB!.mint), data);
+      }
     });
 
     return pools.map((pool, index) => {


### PR DESCRIPTION
Error: read properties of undefined (reading 'mint')
Solution: Add condition making sure mints exist:
```
if (mintA && mintB) {
  poolMap.set(mintA!.mint.concat(mintB!.mint), data);
}
```