### PR TITLE
fix obligation update math

### DIFF
--- a/src/larix/infos.ts
+++ b/src/larix/infos.ts
@@ -546,19 +546,20 @@ export class FarmInfoWrapper implements IFarmInfoWrapper {
 export class ObligationInfoWrapper {
   constructor(public obligationInfo: types.ObligationInfo) {}
 
-  update(
-    reserveAndFarmInfo: {
-      reserve: ReserveInfoWrapper;
-      farm: FarmInfoWrapper;
-    }[]
-  ) {
+  update(reserveAndFarmInfo: { reserve: ReserveInfoWrapper[]; farm: FarmInfoWrapper[] }) {
     let unhealthyBorrowValue = new BN(0);
     let borrowedValue = new BN(0);
     let depositedValue = new BN(0);
     let reserveMap: Map<string, { reserve: ReserveInfoWrapper; farm: FarmInfoWrapper }> = new Map();
-
-    for (let reserveInfoWrapper of reserveAndFarmInfo) {
-      reserveMap.set(reserveInfoWrapper.reserve.reserveInfo.reserveId.toString(), reserveInfoWrapper);
+    let farmMap: Map<string, FarmInfoWrapper> = new Map();
+    for (let farmInfoWrapper of reserveAndFarmInfo.farm) {
+      farmMap.set(farmInfoWrapper.farmInfo.farmId.toString(), farmInfoWrapper);
+    }
+    for (let reserveInfoWrapper of reserveAndFarmInfo.reserve) {
+      reserveMap.set(reserveInfoWrapper.reserveInfo.reserveId.toString(), {
+        reserve: reserveInfoWrapper,
+        farm: farmMap.get(reserveInfoWrapper.reserveInfo.reserveId.toString())!,
+      });
     }
     let unclaimedAmount = this.obligationInfo.unclaimedMine;
 
@@ -579,7 +580,7 @@ export class ObligationInfoWrapper {
           .div(new BN(`1${"".padEnd(2, "0")}`));
         unhealthyBorrowValue = unhealthyBorrowValue.add(thisUnhealthyBorrowValue);
         let indexSub = infoWrapper.farm.farmInfo.lTokenMiningIndex.sub(depositedReserve.index);
-        let reward = indexSub.mul(depositedReserve.depositedAmount);
+        let reward = indexSub.div(depositedReserve.depositedAmount);
         unclaimedAmount = unclaimedAmount.add(reward);
       }
     }
@@ -594,7 +595,7 @@ export class ObligationInfoWrapper {
           .div(new BN(`1${"".padEnd(decimal, "0")}`));
         borrowedValue = borrowedValue.add(thisborrowedValue);
         let indexSub = infoWrapper.farm.farmInfo.borrowMiningIndex.sub(borrowedReserve.index);
-        let reward = indexSub.mul(borrowedReserve.borrowedAmount);
+        let reward = indexSub.div(borrowedReserve.borrowedAmount);
         unclaimedAmount = unclaimedAmount.add(reward);
       }
     }

--- a/test/larix.ts
+++ b/test/larix.ts
@@ -15,16 +15,19 @@ describe("Larix", () => {
   //   commitment: "confirmed",
   //   confirmTransactionInitialTimeout: 180 * 1000,
   // });
-  // const connection = new Connection("https:////api.mainnet-beta.solana.com", {
-  //   commitment: "confirmed",
-  //   confirmTransactionInitialTimeout: 180 * 1000,
-  // });
-  const connection = new Connection("https://rpc-mainnet-fork.epochs.studio", {
+  const connection2 = new Connection("https://api.mainnet-beta.solana.com", {
     commitment: "confirmed",
     confirmTransactionInitialTimeout: 180 * 1000,
-    wsEndpoint: "wss://rpc-mainnet-fork.epochs.studio/ws",
   });
-
+  // const connection = new Connection("https://rpc-mainnet-fork.epochs.studio", {
+  //   commitment: "confirmed",
+  //   confirmTransactionInitialTimeout: 180 * 1000,
+  //   wsEndpoint: "wss://rpc-mainnet-fork.epochs.studio/ws",
+  // });
+  const connection = new Connection("https://cache-rpc.dappio.xyz", {
+    commitment: "confirmed",
+    confirmTransactionInitialTimeout: 180 * 1000,
+  });
   // const options = anchor.AnchorProvider.defaultOptions();
   // const wallet = NodeWallet.local();
   // const provider = new anchor.AnchorProvider(connection, wallet, options);
@@ -32,7 +35,18 @@ describe("Larix", () => {
   // anchor.setProvider(provider);
 
   // const supplyAmount = 20000;
-
+  const userKey = new PublicKey("Weiod39tkAinXHyUszoRtnXxMx1DXUCNWAWdGQxTK2X");
+  it("fetches obligation", async () => {
+    const reserveWrappers = (await larix.infos.getAllReserveWrappers(connection)) as ReserveInfoWrapper[];
+    const farms = (await larix.infos.getAllFarmWrappers(connection)) as FarmInfoWrapper[];
+    let obligations = (await larix.infos.getAllObligations!(connection2, userKey)) as larix.ObligationInfo[];
+    obligations.forEach((o) => {
+      let wrapper = new larix.ObligationInfoWrapper(o);
+      console.log(wrapper.obligationInfo.unclaimedMine.toString());
+      wrapper.update({ reserve: reserveWrappers, farm: farms });
+      console.log(wrapper.obligationInfo.unclaimedMine.toString());
+    });
+  });
   it("fetches reserve", async () => {
     const reserves = (await larix.infos.getAllReserves(connection)) as ReserveInfo[];
     const poolId = reserves[reserves.length - 1].reserveId;


### PR DESCRIPTION
Obligation reward after update is off.
This PR update the math to calculate correct number.
Also change the parameter for `update` in `ObligationInfoWrapper`.
* Change from `{
      reserve: ReserveInfoWrapper;
      farm: FarmInfoWrapper;
    }[]` to `{ reserve: ReserveInfoWrapper[]; farm: FarmInfoWrapper[] }`
