### PR TITLE
Larix bug fix 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dappio-wonderland/navigator",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "Dappio Navigator: The Universal Typescript Client for Instantiating DeFi Protocols",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
The fix in last PR #114 is wrong.
The issue is because `borrowedAmount` have extra 18 decimal.
This PR fix the issue.
It's published to npm.